### PR TITLE
Use Google Services Gradle Plugin Version 4.3.14

### DIFF
--- a/src/android/GoogleSignIn.gradle
+++ b/src/android/GoogleSignIn.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.google.gms:google-services:4.3.10"
+        classpath "com.google.gms:google-services:4.3.14"
     }
 }
 repositories {

--- a/src/android/configureProjectLevelDependency.js
+++ b/src/android/configureProjectLevelDependency.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 
 function addProjectLevelDependency(platformRoot) {
-    const artifactVersion = "com.google.gms:google-services:4.3.10";
+    const artifactVersion = "com.google.gms:google-services:4.3.14";
     const dependency = 'classpath "' + artifactVersion + '"';
 
     const projectBuildFile = path.join(platformRoot, "build.gradle");


### PR DESCRIPTION
This patch will use Google Services Gradle Plugin version 4.3.14 instead of 4.3.10 to address a [project build error when using cordova-android 12](https://github.com/russmedia-digital/cordova-plugin-google-signin/issues/14).